### PR TITLE
Adds bundler configuration for gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+gem "green_shoes"
+gem "ordinalize_full"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    atk (3.0.7)
+      glib2 (= 3.0.7)
+    cairo (1.14.3)
+      pkg-config (>= 1.1.5)
+    gdk_pixbuf2 (3.0.7)
+      glib2 (= 3.0.7)
+    glib2 (3.0.7)
+      pkg-config
+    green_shoes (1.1.374)
+      gtk2
+    gtk2 (3.0.7)
+      atk (= 3.0.7)
+      gdk_pixbuf2 (= 3.0.7)
+      pango (= 3.0.7)
+    i18n (0.7.0)
+    ordinalize_full (1.3.0)
+      i18n (~> 0.7.0)
+    pango (3.0.7)
+      cairo (>= 1.14.0)
+      glib2 (= 3.0.7)
+    pkg-config (1.1.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  green_shoes
+  ordinalize_full
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Dependencies:
 
     gem install green_shoes
 
+[OrdinalizeFull](https://github.com/infertux/ordinalize_full) turns a number into an ordinal string such as first, second, third or 1st, 2nd, 3rd
+
+    gem install ordinalize_full
+
+or install all dependencies with bundler
+
+    bundle install
 
 Screenshot:
 ----------


### PR DESCRIPTION
Defining dependencies with bundler really helps people get going with your tool quickly! It also simplifies documentation :)

I added `ordinalize_full` as a dependency, because my OS X machine complained that it was missing.